### PR TITLE
fix: Reimplement Widgets.ButtonText

### DIFF
--- a/Source/Actions/AnimationAction.cs
+++ b/Source/Actions/AnimationAction.cs
@@ -49,7 +49,7 @@ public class AnimationAction : LevelingAction
     {
         var rowRect = new Rect(rect) { height = 24f };
         var buttonRect = new Rect(rowRect) { width = rowRect.width / 2 };
-        if (Widgets.ButtonText(buttonRect, animation.Label))
+        if (CustomWidgets.ButtonText(buttonRect, animation.Label))
         {
             var options = animations
                 .Select(x => new FloatMenuOption(x.Label, () => Select(x)))

--- a/Source/Actions/SoundAction.cs
+++ b/Source/Actions/SoundAction.cs
@@ -47,7 +47,7 @@ public class SoundAction : LevelingAction
     {
         var rowRect = new Rect(rect) { height = 24f };
         var soundDefRect = new Rect(rowRect) { width = rect.width / 2 };
-        if (Widgets.ButtonText(soundDefRect, soundDef.LabelCap))
+        if (CustomWidgets.ButtonText(soundDefRect, soundDef.LabelCap))
         {
             var options = allSounds
                 .Select(x => new FloatMenuOption(x.LabelCap, () => soundDef = x))

--- a/Source/CustomWidgets.cs
+++ b/Source/CustomWidgets.cs
@@ -1,0 +1,47 @@
+﻿using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace LevelUp;
+
+internal static class CustomWidgets
+{
+    private static readonly Texture2D buttonBGAtlasMouseover = ContentFinder<Texture2D>.Get("UI/Widgets/ButtonBGMouseover");
+
+    // Essentially a stable re-implementation of 1.3 Widgets.ButtonText.
+    // The method has different signatures in 1.3 and 1.4, and having a custom version here avoids having to
+    // re-compile the mod against multiple versions of the game.
+    internal static bool ButtonText(Rect rect, string label)
+    {
+        var anchor = Text.Anchor;
+        var color = GUI.color;
+
+        var atlas = Widgets.ButtonBGAtlas;
+        if (Mouse.IsOver(rect))
+        {
+            atlas = buttonBGAtlasMouseover;
+            if (Input.GetMouseButton(0))
+            {
+                atlas = Widgets.ButtonBGAtlasClick;
+            }
+        }
+        Widgets.DrawAtlas(rect, atlas);
+        MouseoverSounds.DoRegion(rect);
+
+        Text.Anchor = TextAnchor.MiddleCenter;
+
+        var wordWrap = Text.WordWrap;
+        if (rect.height < Text.LineHeight * 2f)
+        {
+            Text.WordWrap = false;
+        }
+        Widgets.Label(rect, label);
+        Text.Anchor = anchor;
+        GUI.color = color;
+        Text.WordWrap = wordWrap;
+
+        var result = Widgets.ButtonInvisible(rect, false) ? Widgets.DraggableResult.Pressed : Widgets.DraggableResult.Idle;
+
+        return result is Widgets.DraggableResult.Pressed or Widgets.DraggableResult.DraggedThenPressed;
+    }
+}


### PR DESCRIPTION
Replaces all uses of `Widgets.ButtonText` with custom reimplementation.

The signature of `Widgets.ButtonText` is different in **1.3** and **1.4**. Using a stable, custom version of the method allows LevelUp to avoid separate compilations for **1.3** and **1.4**.

The reimplementation is basically a shortened version of the same method in **1.3**.