### PR TITLE
Add StaticConstructorOnStartup for CustomWidgets

### DIFF
--- a/Source/CustomWidgets.cs
+++ b/Source/CustomWidgets.cs
@@ -4,6 +4,7 @@ using Verse.Sound;
 
 namespace LevelUp;
 
+[StaticConstructorOnStartup]
 internal static class CustomWidgets
 {
     private static readonly Texture2D buttonBGAtlasMouseover = ContentFinder<Texture2D>.Get("UI/Widgets/ButtonBGMouseover");


### PR DESCRIPTION
Adds StaticConstructorOnStartup to CustomWidgets to ensure assets are loaded in the main thread (but mostly to prevent Rimworld from complaining about it in the logs)