### PR TITLE
Use FleckMaker to create Flecks

### DIFF
--- a/Source/Actions/FleckAnimation.cs
+++ b/Source/Actions/FleckAnimation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using RimWorld;
 using UnityEngine;
 using Verse;
 
@@ -68,23 +69,19 @@ public class FleckAnimation : IAnimation
             return;
         }
 
-        var fleckData = new FleckCreationData
-        {
-            def = fleckDef,
-            exactScale = animationExtension.ExactScale,
-            scale = animationExtension.Scale,
-            rotation = animationExtension.Rotation,
-            rotationRate = animationExtension.RotationRate,
-            solidTimeOverride = animationExtension.SolidTimeOverride,
-            airTimeLeft = animationExtension.AirTimeLeft,
-            targetSize = animationExtension.TargetSize,
-            velocity = animationExtension.Velocity,
-            velocityAngle = animationExtension.VelocityAngle,
-            velocitySpeed = animationExtension.VelocitySpeed,
-            instanceColor = animationExtension.InstanceColor,
-            spawnPosition = pawn.DrawPos,
-            link = new FleckAttachLink(pawn)
-        };
+        var fleckData = FleckMaker.GetDataStatic(pawn.DrawPos, pawnMap, fleckDef);
+        fleckData.exactScale = animationExtension.ExactScale;
+        fleckData.scale = animationExtension.Scale;
+        fleckData.rotation = animationExtension.Rotation;
+        fleckData.rotationRate = animationExtension.RotationRate;
+        fleckData.solidTimeOverride = animationExtension.SolidTimeOverride;
+        fleckData.airTimeLeft = animationExtension.AirTimeLeft;
+        fleckData.targetSize = animationExtension.TargetSize;
+        fleckData.velocity = animationExtension.Velocity;
+        fleckData.velocityAngle = animationExtension.VelocityAngle;
+        fleckData.velocitySpeed = animationExtension.VelocitySpeed;
+        fleckData.instanceColor = animationExtension.InstanceColor;
+        fleckData.link = new FleckAttachLink(pawn);
 
         pawnMap.flecks.CreateFleck(fleckData);
     }


### PR DESCRIPTION
Level Up! creates `FleckCreationData` directly. However, 1.4 introduces a new field on `FleckCreationData`; `ageTickOverride`. Not setting this causes the Level Up-animations not to show. Setting it to `-1` fixes this problem, but the default is `0`. However, it's not possible to set it explicitly without having to start maintaining two assemblies, one for 1.3, where this value is not set, and one for 1.4, where it is set.

Luckily, there's a factory method for `FleckCreationData` on `FleckMaker` that sets this value to `-1` in 1.4, but not in 1.3. This change replaces the direct construction of `FleckCreationData` with the factory version.