### PR TITLE
Remove temp Pawn statue fix causing errors on world trade

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -3,7 +3,7 @@
   <name>Level Up!</name>
   <author>krafs</author>
   <packageId>Krafs.LevelUp</packageId>
-  <modVersion IgnoreIfNoMatchingField="True">5.3.0</modVersion>
+  <modVersion IgnoreIfNoMatchingField="True">5.3.1</modVersion>
   <modIconPath IgnoreIfNoMatchingField="True">LevelUp/Icon</modIconPath>
   <description>Level up notifications!</description>
   <url>https://github.com/krafs/LevelUp</url>

--- a/LevelUp.csproj
+++ b/LevelUp.csproj
@@ -22,7 +22,7 @@
   
   <ItemGroup>
     <PackageReference Include="Krafs.Rimworld.Ref" Version="$(RimworldVersion).*"/>
-    <PackageReference Include="Lib.Harmony" Version="2.3.6" ExcludeAssets="runtime" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.7-prerelease" ExcludeAssets="runtime" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/Patcher.cs
+++ b/Source/Patcher.cs
@@ -1,7 +1,6 @@
 using HarmonyLib;
 using RimWorld;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using UnityEngine;
 using Verse;
@@ -31,20 +30,14 @@ internal static class Patcher
 #endif
     }
 
-    private static void Prefix(out int __state, SkillRecord __instance, Pawn ___pawn)
+    private static void Prefix(out int __state, SkillRecord __instance)
     {
-        if (!___pawn.IsFreeColonist)
-        {
-            __state = -1;
-            return;
-        }
-        
         __state = __instance.Level;
     }
 
     private static void DirtyAptitudesPostfix(int __state, SkillRecord __instance, Pawn ___pawn)
     {
-        if (__state == -1)
+        if (!___pawn.IsFreeColonist)
         {
             return;
         }
@@ -76,7 +69,7 @@ internal static class Patcher
 
     private static void LearnPostfix(int __state, SkillRecord __instance, Pawn ___pawn, bool direct)
     {
-        if (__state == -1)
+        if (!___pawn.IsFreeColonist)
         {
             return;
         }


### PR DESCRIPTION
May also fix compatibility with mods with pawns that should not level, like Synstructs and Androids. The level value passed between fixes in __state might end up being 0, which almost never equals Level, causing LevelUp to see it as a level change, and show notifications when it shouldn't.